### PR TITLE
merge candidates in _absorb instead of overwriting them

### DIFF
--- a/phoenixAES/phoenixAES/__init__.py
+++ b/phoenixAES/phoenixAES/__init__.py
@@ -508,7 +508,11 @@ def _absorb(index, o, candidates, goldenrefbytes, encrypt, verbose):
             for loc0,loc1,loc2,loc3 in candidates[index]:
                 if (lc0 & loc0) and (lc1 & loc1) and (lc2 & loc2) and (lc3 & loc3):
                     new_candidates.append(((lc0 & loc0), (lc1 & loc1), (lc2 & loc2), (lc3 & loc3)))
-        candidates[index]=new_candidates
+        # candidates[index]=new_candidates
+        if new_candidates != []:
+            candidates[index]=new_candidates
+        else:
+            candidates[index] += Cands
 
 def _get_cands(Diff, Keys, tmult, encrypt, verbose):
     candi = [_get_compat(di, ti, encrypt) for di,ti in zip(Diff, tmult)]


### PR DESCRIPTION
PR for #6 

I've generated a set of 105 faulty outputs that are the result of injecting a fault at the output of R9 SubBytes using the following logic:
```
def double_byte_multi_bit_flip(s):
    for _ in range(2):
        i = random.choice(range(4))
        j = random.choice(range(4))
        for _ in range(4):
            bit = random.choice(range(8))
            s[i][j] = s[i][j] ^ (1<<bit)
```

Outputs are in [tracefile.zip](https://github.com/SideChannelMarvels/JeanGrey/files/4525360/tracefile.zip), first line is correct output.

I've tested it with this:
```
from phoenixAES.phoenixAES import crack_file

key        = bytes.fromhex('536944654368614e6e654c4d6172566c')
message    = bytes.fromhex('73557045725345635245746d45537347')
ciphertext = bytes.fromhex('abf7e913fffc2db70d99cc3faa2d1ecf')
ik10       = bytes.fromhex('8b7db064f81ef79e3ca654be98908b17')

print(ik10.hex())
print(crack_file('tracefile'))
```

With the current _absorb(), only one row is recovered:
```
8b7db064f81ef79e3ca654be98908b17
8B............9E....54....90....
```

By merging the candidates, all rows are recovered:
```
8b7db064f81ef79e3ca654be98908b17
Last round key #N found:
8B7DB064F81EF79E3CA654BE98908B17
8B7DB064F81EF79E3CA654BE98908B17
```

